### PR TITLE
Add "zoom out to whole state" control

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,11 +36,11 @@
 			function populateZoomControl(selectID, sourceID, fieldName, layerName) {
 				polygons = getPolygons(sourceID, fieldName);
 				var select = document.getElementById(selectID);
-				select.options[0] = new Option(layerName);
+				select.options[0] = new Option(layerName, "-108,25,-88,37,0");
 				for (i in polygons) {
 					select.options[select.options.length] = new Option(
 						polygons[i].name,
-						polygons[i].bbox
+						polygons[i].bbox.toString() + ',' + polygons[i].name
 					);
 				}
 			}

--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
 				}
 			}
 
+
+
 			function getPolygons(sourceID, nameField) {
 				layerID = map.getSource(sourceID).vectorLayerIds[0];
 				features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
@@ -328,8 +330,8 @@ map.on('load', function () {
 						'visibleOnLoad': false, // set this optional argument to true to have the layer visible on load. Leave out or set to false to have it hidden on load
 						'usedInZoomControl': true // set this optional argument to true if this layer will be used in the Zoom to Districts control, otherwise leave it out or set it to false.
 					}
-				);		
-				
+				);
+
 				addVectorLayer(
 					map,
 					{
@@ -428,10 +430,10 @@ map.on('load', function () {
 		  map.on('mouseenter', 'charter-schools-v2', showPopup);
 		  map.on('mouseleave', 'charter-schools-v2', hidePopup);
 
-*/		  
-		  
+*/
+
 			runWhenLoadComplete();
-		
+
 
 		}); // end of map.on(load) block
 

--- a/index.html
+++ b/index.html
@@ -36,16 +36,14 @@
 			function populateZoomControl(selectID, sourceID, fieldName, layerName) {
 				polygons = getPolygons(sourceID, fieldName);
 				var select = document.getElementById(selectID);
-				select.options[0] = new Option(layerName, "-108,25,-88,37,0");
+				select.options[0] = new Option(layerName, "-108,25,-88,37");
 				for (i in polygons) {
 					select.options[select.options.length] = new Option(
 						polygons[i].name,
-						polygons[i].bbox.toString() + ',' + polygons[i].name
+						polygons[i].bbox
 					);
 				}
 			}
-
-
 
 			function getPolygons(sourceID, nameField) {
 				layerID = map.getSource(sourceID).vectorLayerIds[0];


### PR DESCRIPTION
It's nice when my first hunch actually turns out to be correct....

All I had to do was copy how ryht-legislative sets up the first item in the dropdown (the one that says "Texas School Districts" instead of a district name) to have hard-coded coordinates for a bounding box that covers the whole state.

ryht-legislative does a bunch of other things too, like including the district name in those option values, and some fancy CSS work, but those only matter for fading out the other districts.  If you or RYHT want to add that feature, it'll be worth asking me to do it, because it won't take me long at all to pick out the relevant bits from ryht-legislative and copy them over, but it probably would take a while to figure out from scratch.